### PR TITLE
Changed prometheus_client requirement to be a little less constrictive

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ exclude = []
 [tool.poetry.dependencies]
 python = "^3.6"
 starlette = ">=0.12.0"
-prometheus_client = ">=0.5.0 <1.0.0"
+prometheus_client = "^0.5"
 
 [tool.poetry.dev-dependencies]
 pytest = "^3.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ exclude = []
 [tool.poetry.dependencies]
 python = "^3.6"
 starlette = ">=0.12.0"
-prometheus_client = "^0.5.0"
+prometheus_client = ">=0.5.0 <1.0.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^3.6"


### PR DESCRIPTION
For some reason ^0.5.0 expands to >=0.5.0 <0.6.0 instead of >=0.5.0 <1.0.0 the second one is what is promised by the poetry docs but the first one is what is actually happening.