### PR TITLE
[FEATURE] Group unhandled paths

### DIFF
--- a/starlette_prometheus/middleware.py
+++ b/starlette_prometheus/middleware.py
@@ -33,12 +33,8 @@ REQUESTS_IN_PROGRESS = Gauge(
 
 
 class PrometheusMiddleware(BaseHTTPMiddleware):
-
     def __init__(
-            self,
-            app: ASGIApp,
-            group_unhandled_paths: bool = False,
-            unhandled_paths_str: str = "unhandled_paths",
+        self, app: ASGIApp, group_unhandled_paths: bool = False, unhandled_paths_str: str = "unhandled_paths",
     ) -> None:
         super().__init__(app)
         self.group_unhandled_paths = group_unhandled_paths

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -105,7 +105,8 @@ class TestCasePrometheusMiddleware:
 
         # Asserts: Responses
         assert (
-            'starlette_responses_total{method="GET",path_template="/any/unhandled/path",status_code="404"} 1.0' in metrics_text
+            'starlette_responses_total{method="GET",path_template="/any/unhandled/path",status_code="404"} 1.0'
+            in metrics_text
         )
 
         # Asserts: Requests in progress
@@ -139,7 +140,8 @@ class TestCasePrometheusMiddlewareGroupUnhandledPaths:
 
         # Asserts: Responses
         assert (
-            'starlette_responses_total{method="GET",path_template="unhandled_paths",status_code="404"} 1.0' in metrics_text
+            'starlette_responses_total{method="GET",path_template="unhandled_paths",status_code="404"} 1.0'
+            in metrics_text
         )
 
         # Asserts: Requests in progress


### PR DESCRIPTION
In order to reduce cardinality of prometheus metrics and [labels](https://prometheus.io/docs/practices/instrumentation/#do-not-overuse-labels),
this pull request adds an option to group all metrics that do not match any route.

This solves the problem of random path requests generating unwanted metrics (each requested path generates around 23 lines of metrics), which could potentially be a big issue if exposed to the internet.