### PR TITLE
User `time.perf_counter` to measure the response latency

### DIFF
--- a/starlette_prometheus/middleware.py
+++ b/starlette_prometheus/middleware.py
@@ -39,9 +39,9 @@ class PrometheusMiddleware(BaseHTTPMiddleware):
         REQUESTS_IN_PROGRESS.labels(method=method, path_template=path_template).inc()
         REQUESTS.labels(method=method, path_template=path_template).inc()
         try:
-            before_time = time.time()
+            before_time = time.perf_counter()
             response = await call_next(request)
-            after_time = time.time()
+            after_time = time.perf_counter()
         except Exception as e:
             EXCEPTIONS.labels(method=method, path_template=path_template, exception_type=type(e).__name__).inc()
             raise e from None


### PR DESCRIPTION
The `time.perf_counter()`:
* is monotonic, which means it can only go forward
* is not adjustable, which means it can't be changed by the system administrator
* it has higher tick rate (ticks per second) and lower resolution (the time between clock ticks) than `time.time()`

This is also a recommended way of measuring performance according to the authors of the PEP418:

> The new time.perf_counter() function should be used instead to always get the most precise performance counter with a portable behaviour (ex: include time spend during sleep).

Source: https://www.python.org/dev/peps/pep-0418/#choosing-the-clock-from-a-list-of-constraints