### PR TITLE
Filter unhandled paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ app.add_middleware(PrometheusMiddleware)
 app.add_route("/metrics/", metrics)
 ```
 
+Metrics for paths that do not match any Starlette route can be filtered by passing
+`filter_unhandled_paths=True` argument to `add_middleware` method.
+
 ## Contributing
 
 This project is absolutely open to contributions so if you have a nice idea, create an issue to let the community 

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -91,3 +91,53 @@ class TestCasePrometheusMiddleware:
         # Asserts: Requests in progress
         assert 'starlette_requests_in_progress{method="GET",path_template="/foo/{bar}/"} 0.0' in metrics_text
         assert 'starlette_requests_in_progress{method="GET",path_template="/metrics/"} 1.0' in metrics_text
+
+    def test_unhandled_paths(self, client):
+        # Do a request
+        client.get("/any/unhandled/path")
+
+        # Get metrics
+        response = client.get("/metrics/")
+        metrics_text = response.content.decode()
+
+        # Asserts: Requests
+        assert 'starlette_requests_total{method="GET",path_template="/any/unhandled/path"} 1.0' in metrics_text
+
+        # Asserts: Responses
+        assert (
+            'starlette_responses_total{method="GET",path_template="/any/unhandled/path",status_code="404"} 1.0'
+            in metrics_text
+        )
+
+        # Asserts: Requests in progress
+        assert 'starlette_requests_in_progress{method="GET",path_template="/any/unhandled/path"} 0.0' in metrics_text
+        assert 'starlette_requests_in_progress{method="GET",path_template="/metrics/"} 1.0' in metrics_text
+
+
+class TestCasePrometheusMiddlewareFilterUnhandledPaths:
+    @pytest.fixture(scope="class")
+    def app(self):
+        app_ = Starlette()
+        app_.add_middleware(PrometheusMiddleware, filter_unhandled_paths=True)
+        app_.add_route("/metrics/", metrics)
+
+        return app_
+
+    @pytest.fixture
+    def client(self, app):
+        return TestClient(app)
+
+    def test_filter_unhandled_paths(self, client):
+        # Do a request
+        path = "/other/unhandled/path"
+        client.get(path)
+
+        # Get metrics
+        response = client.get("/metrics/")
+        metrics_text = response.content.decode()
+
+        # Asserts: metric is filtered
+        assert path not in metrics_text
+
+        # Asserts: Requests in progress
+        assert 'starlette_requests_in_progress{method="GET",path_template="/metrics/"} 1.0' in metrics_text


### PR DESCRIPTION
As discussed in #10, this PR adds an optional feature to filter metrics that do not match any route.