### PR TITLE
Fix duplicated charset in the content-type header

### DIFF
--- a/starlette_prometheus/view.py
+++ b/starlette_prometheus/view.py
@@ -13,4 +13,4 @@ def metrics(request: Request) -> Response:
     else:
         registry = REGISTRY
 
-    return Response(generate_latest(registry), media_type=CONTENT_TYPE_LATEST)
+    return Response(generate_latest(registry), headers={"Content-Type": CONTENT_TYPE_LATEST})

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -80,6 +80,9 @@ class TestCasePrometheusMiddleware:
         response = client.get("/metrics/")
         metrics_text = response.content.decode()
 
+        # Asserts: Headers
+        assert response.headers["content-type"] == "text/plain; version=0.0.4; charset=utf-8"
+
         # Asserts: Requests
         assert 'starlette_requests_total{method="GET",path_template="/foo/{bar}/"} 1.0' in metrics_text
 


### PR DESCRIPTION
The `CONTENT_TYPE_LATEST` constant from the `prometheus_client` already contains not only media type but also charset value. On the other hand, starlette adds charset value to a value passed as `media_type` ([related place in code](https://github.com/encode/starlette/blob/99b37781eb88cfc2f7064724975ac5d93d623ea7/starlette/responses.py#L85)). 

This causes charset value duplication like: `text/plain; version=0.0.4; charset=utf-8; charset=utf-8`.