### PR TITLE
⚡️update processing flow to handle exception

### DIFF
--- a/starlette_prometheus/middleware.py
+++ b/starlette_prometheus/middleware.py
@@ -6,6 +6,7 @@ from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoin
 from starlette.requests import Request
 from starlette.responses import Response
 from starlette.routing import Match
+from starlette.status import HTTP_500_INTERNAL_SERVER_ERROR
 from starlette.types import ASGIApp
 
 REQUESTS = Counter(
@@ -50,16 +51,17 @@ class PrometheusMiddleware(BaseHTTPMiddleware):
         try:
             before_time = time.perf_counter()
             response = await call_next(request)
-            after_time = time.perf_counter()
+            status_code = response.status_code
         except Exception as e:
+            status_code = HTTP_500_INTERNAL_SERVER_ERROR
             EXCEPTIONS.labels(method=method, path_template=path_template, exception_type=type(e).__name__).inc()
             raise e from None
-        else:
+        finally:
+            after_time = time.perf_counter()
             REQUESTS_PROCESSING_TIME.labels(method=method, path_template=path_template).observe(
                 after_time - before_time
             )
-            RESPONSES.labels(method=method, path_template=path_template, status_code=response.status_code).inc()
-        finally:
+            RESPONSES.labels(method=method, path_template=path_template, status_code=status_code).inc()
             REQUESTS_IN_PROGRESS.labels(method=method, path_template=path_template).dec()
 
         return response


### PR DESCRIPTION
The idea is to handle RESPONSES metrics and REQUESTS monitoring in any case (error caught or not), and inferring response status code with HTTP 500 when exception is caught. The processing time is computed in the `finally` scope which shouldn't be that much a time overhead.

Related to issue https://github.com/perdy/starlette-prometheus/issues/21