### PR TITLE
Record exceptions as 500 responses

### DIFF
--- a/starlette_prometheus/middleware.py
+++ b/starlette_prometheus/middleware.py
@@ -6,6 +6,7 @@ from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoin
 from starlette.requests import Request
 from starlette.responses import Response
 from starlette.routing import Match
+from starlette.status import HTTP_500_INTERNAL_SERVER_ERROR
 from starlette.types import ASGIApp
 
 REQUESTS = Counter(
@@ -51,15 +52,17 @@ class PrometheusMiddleware(BaseHTTPMiddleware):
         try:
             response = await call_next(request)
         except Exception as e:
+            status_code = HTTP_500_INTERNAL_SERVER_ERROR
             EXCEPTIONS.labels(method=method, path_template=path_template, exception_type=type(e).__name__).inc()
             raise e from None
         else:
+            status_code = response.status_code
             after_time = time.perf_counter()
             REQUESTS_PROCESSING_TIME.labels(method=method, path_template=path_template).observe(
                 after_time - before_time
             )
-            RESPONSES.labels(method=method, path_template=path_template, status_code=response.status_code).inc()
         finally:
+            RESPONSES.labels(method=method, path_template=path_template, status_code=status_code).inc()
             REQUESTS_IN_PROGRESS.labels(method=method, path_template=path_template).dec()
 
         return response

--- a/starlette_prometheus/middleware.py
+++ b/starlette_prometheus/middleware.py
@@ -47,14 +47,14 @@ class PrometheusMiddleware(BaseHTTPMiddleware):
 
         REQUESTS_IN_PROGRESS.labels(method=method, path_template=path_template).inc()
         REQUESTS.labels(method=method, path_template=path_template).inc()
+        before_time = time.perf_counter()
         try:
-            before_time = time.perf_counter()
             response = await call_next(request)
-            after_time = time.perf_counter()
         except Exception as e:
             EXCEPTIONS.labels(method=method, path_template=path_template, exception_type=type(e).__name__).inc()
             raise e from None
         else:
+            after_time = time.perf_counter()
             REQUESTS_PROCESSING_TIME.labels(method=method, path_template=path_template).observe(
                 after_time - before_time
             )

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -67,6 +67,9 @@ class TestCasePrometheusMiddleware:
             'exception_type="ValueError",method="GET",path_template="/bar/"'
             "} 1.0" in metrics_text
         )
+        assert (
+            "starlette_responses_total{" 'method="GET",path_template="/bar/",status_code="500"' "} 1.0" in metrics_text
+        )
 
         # Asserts: Requests in progress
         assert 'starlette_requests_in_progress{method="GET",path_template="/bar/"} 0.0' in metrics_text


### PR DESCRIPTION
This way it will be possible to count the number of 5xx responses with: `sum(rate(starlette_responses_total{status_code=~"50."}[1m]))` query.

Fixes https://github.com/perdy/starlette-prometheus/issues/21