### PR TITLE
WIP: Add test for prometheus_multiproc_dir

### DIFF
--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -119,6 +119,30 @@ class TestCasePrometheusMiddleware:
         assert 'starlette_requests_in_progress{method="GET",path_template="/any/unhandled/path"} 0.0' in metrics_text
         assert 'starlette_requests_in_progress{method="GET",path_template="/metrics/"} 1.0' in metrics_text
 
+    def test_prometheus_multiproc_dir(self, client, monkeypatch):
+        # Set environment variable to default os tmp folder
+        monkeypatch.setenv("prometheus_multiproc_dir", "/tmp")
+
+        # Do a request
+        client.get("/foo/")
+
+        # Get metrics
+        response = client.get("/metrics/")
+
+        # Asserts: status code is OK
+        assert response.status_code == 200
+
+        metrics_text = response.content.decode()
+
+        # TODO Asserts: Requests
+        # assert 'starlette_requests_total{method="GET",path_template="/foo/"} 1.0' in metrics_text
+
+        # TODO # Asserts: Responses
+        # assert 'starlette_responses_total{method="GET",path_template="/foo/",status_code="200"} 1.0' in metrics_text
+
+        # TODO # Asserts: Requests in progress
+        # assert 'starlette_requests_in_progress{method="GET",path_template="/foo/"} 0.0' in metrics_text
+        # assert 'starlette_requests_in_progress{method="GET",path_template="/metrics/"} 1.0' in metrics_text
 
 class TestCasePrometheusMiddlewareFilterUnhandledPaths:
     @pytest.fixture(scope="class")


### PR DESCRIPTION
I was wondering if we could add a test for the situation in which the environment variable `prometheus_multiproc_dir` is set, thus reaching 100% coverage. The problem is that we get a status code 200 OK, but the content of the response is empty. It would be nice if you have suggestions on how to correctly mock the processing using the `prometheus_multiproc_dir`. Many thanks and best regards.  