### PR TITLE
Fix: "UnboundLocalError: local variable 'status_code' referenced before assignment"

### DIFF
--- a/starlette_prometheus/middleware.py
+++ b/starlette_prometheus/middleware.py
@@ -51,7 +51,7 @@ class PrometheusMiddleware(BaseHTTPMiddleware):
         before_time = time.perf_counter()
         try:
             response = await call_next(request)
-        except Exception as e:
+        except BaseException as e:
             status_code = HTTP_500_INTERNAL_SERVER_ERROR
             EXCEPTIONS.labels(method=method, path_template=path_template, exception_type=type(e).__name__).inc()
             raise e from None


### PR DESCRIPTION
Not all of the errors thrown by asyncio inherit from Exception. I was throwing an exception in a route to test my sentry intergration and it threw a asyncio.exceptions.CancelledError which inherits from BaseException (see https://github.com/python/cpython/blob/3.9/Lib/asyncio/exceptions.py#L9)