### PR TITLE
respect PROMETHEUS_MULTIPROC_DIR in example metrics view

### DIFF
--- a/starlette_prometheus/view.py
+++ b/starlette_prometheus/view.py
@@ -6,7 +6,7 @@ from starlette.responses import Response
 
 
 def metrics(request: Request) -> Response:
-    if "prometheus_multiproc_dir" in os.environ:
+    if "prometheus_multiproc_dir" in os.environ or "PROMETHEUS_MULTIPROC_DIR" in os.environ:
         registry = CollectorRegistry()
         MultiProcessCollector(registry)
     else:


### PR DESCRIPTION
Hey

Since `prometheus_client:0.10.x` deprecated `prometheus_multiproc_dir` in favor of `PROMETHEUS_MULTIPROC_DIR`.
So I updated the example `metrics` view to also respect `PROMETHEUS_MULTIPROC_DIR` - wdyt?
